### PR TITLE
Refactor: change from buildParser to generate

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function buildParser(filename, options) {
   var newParser;
 
   try {
-    newParser = peg.buildParser(grammar.text, combinedOptions);
+    newParser = peg.generate(grammar.text, combinedOptions);
   } catch(e) {
 
     if (e instanceof peg.GrammarError) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var fs = require('fs'),
 var parsers = {},
   importStack = [];
 
-function buildParser(filename, options) {
+function generate(filename, options) {
 
   // if we've already imported this file, don't touch it again
   if (parsers[filename]) {
@@ -50,7 +50,7 @@ function buildParser(filename, options) {
 
     var parser;
     try {
-      parser = buildParser(dependency.path, options);
+      parser = generate(dependency.path, options);
     } catch(e) {
       if (e instanceof peg.GrammarError) {
         throw new peg.GrammarError(dependency.path + ': ' + e.message + '\n');
@@ -102,4 +102,4 @@ function buildParser(filename, options) {
   return newParser;
 
 };
-module.exports = { buildParser: buildParser };
+module.exports = { generate };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegjs-import",
-  "version": "0.2.7",
+  "version": "1.2.7",
   "description": "Import other PEG files into a PEG.js grammar.",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   "author": "Harry Schmidt",
   "license": "MIT",
   "repository": {
-    "type" : "git",
-    "url" : "http://github.com/casetext/pegjs-import.git"
+    "type": "git",
+    "url": "http://github.com/casetext/pegjs-import.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegjs-import",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Import other PEG files into a PEG.js grammar.",
   "main": "index.js",
   "scripts": {
@@ -15,11 +15,11 @@
     "require"
   ],
   "dependencies": {
-    "pegjs": "^0.8.0"
+    "pegjs": "^0.10.0"
   },
   "devDependencies": {
-    "chai": "^1.9.2",
-    "mocha": "^1.21.5"
+    "chai": "^3.5.0",
+    "mocha": "^3.0.2"
   },
   "author": "Harry Schmidt",
   "license": "MIT",

--- a/test/spec/core.js
+++ b/test/spec/core.js
@@ -10,7 +10,7 @@ describe('peg-import', function() {
 
     var parser;
 
-    parser = pegimport.buildParser('test/fixtures/import.peg');
+    parser = pegimport.generate('test/fixtures/import.peg');
 
     expect(function() {
       parser.parse('0123456789');
@@ -29,7 +29,7 @@ describe('peg-import', function() {
   it('only imports initializers once', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/initializer.peg');
+      pegimport.generate('test/fixtures/initializer.peg');
     }).not.to.throw();
 
   });
@@ -37,7 +37,7 @@ describe('peg-import', function() {
   it('imports initializers in the correct order', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/initializer2.peg');
+      pegimport.generate('test/fixtures/initializer2.peg');
     }).not.to.throw();
 
   });
@@ -45,7 +45,7 @@ describe('peg-import', function() {
   it('detects circular dependencies', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/circle/left.peg');
+      pegimport.generate('test/fixtures/circle/left.peg');
     }).to.throw(peg.GrammarError);
 
   });
@@ -53,7 +53,7 @@ describe('peg-import', function() {
   it('passes options straight through', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/initializer.peg', { optimize: 'size' });
+      pegimport.generate('test/fixtures/initializer.peg', { optimize: 'size' });
     }).not.to.throw();
 
   });
@@ -61,7 +61,7 @@ describe('peg-import', function() {
   it('treats internal rule name references correctly', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/rulerefs.peg');
+      pegimport.generate('test/fixtures/rulerefs.peg');
     }).not.to.throw();
 
   });


### PR DESCRIPTION
This PR is for refactoring the method named buildParser to generate. This is necessary to reflect pegjs change in version ^0.10.0.