### PR TITLE
Dependency update to latest PEG.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ npm install --save pegjs pegjs-import
 
 ## Usage
 
-pegjs-import provides a single function that replaces ```peg.buildParser```:
+pegjs-import provides a single function that replaces ```peg.generate```:
 
 ```javascript
   var pegimport = require('pegjs-import');
 
-  var parser = pegimport.buildParser('path/to/grammar.peg', options);
+  var parser = pegimport.generate('path/to/grammar.peg', options);
   parser.parse('foo');
 ```
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var fs = require('fs'),
 var parsers = {},
   importStack = [];
 
-function buildParser(filename, options) {
+function generate(filename, options) {
 
   // if we've already imported this file, don't touch it again
   if (parsers[filename]) {
@@ -50,7 +50,7 @@ function buildParser(filename, options) {
 
     var parser;
     try {
-      parser = buildParser(dependency.path, options);
+      parser = generate(dependency.path, options);
     } catch(e) {
       if (e instanceof peg.GrammarError) {
         throw new peg.GrammarError(dependency.path + ': ' + e.message + '\n');
@@ -84,7 +84,7 @@ function buildParser(filename, options) {
   var newParser;
 
   try {
-    newParser = peg.buildParser(grammar.text, combinedOptions);
+    newParser = peg.generate(grammar.text, combinedOptions);
   } catch(e) {
 
     if (e instanceof peg.GrammarError) {
@@ -102,4 +102,4 @@ function buildParser(filename, options) {
   return newParser;
 
 };
-module.exports = { buildParser: buildParser };
+module.exports = { generate: generate };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Import other PEG files into a PEG.js grammar.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha -r test/setup test/spec/**/*.js"
+    "test": "mocha test/spec/**/*.js"
   },
   "keywords": [
     "pegjs",
@@ -19,12 +19,12 @@
   },
   "devDependencies": {
     "chai": "^1.9.2",
-    "mocha": "^1.21.5"
+    "mocha": "^8.2.0"
   },
   "author": "Harry Schmidt",
   "license": "MIT",
   "repository": {
-    "type" : "git",
-    "url" : "http://github.com/casetext/pegjs-import.git"
+    "type": "git",
+    "url": "http://github.com/casetext/pegjs-import.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "require"
   ],
   "dependencies": {
-    "pegjs": "^0.8.0"
+    "pegjs": "^0.10.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pegjs": "^0.8.0"
   },
   "devDependencies": {
-    "chai": "^1.9.2",
+    "chai": "^4.2.0",
     "mocha": "^8.2.0"
   },
   "author": "Harry Schmidt",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,0 @@
-
-'use strict';
-
-global.expect = require('chai').expect;

--- a/test/spec/core.js
+++ b/test/spec/core.js
@@ -11,7 +11,7 @@ describe('peg-import', function() {
 
     var parser;
 
-    parser = pegimport.buildParser('test/fixtures/import.peg');
+    parser = pegimport.generate('test/fixtures/import.peg');
 
     expect(function() {
       parser.parse('0123456789');
@@ -30,7 +30,7 @@ describe('peg-import', function() {
   it('only imports initializers once', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/initializer.peg');
+      pegimport.generate('test/fixtures/initializer.peg');
     }).not.to.throw();
 
   });
@@ -38,7 +38,7 @@ describe('peg-import', function() {
   it('imports initializers in the correct order', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/initializer2.peg');
+      pegimport.generate('test/fixtures/initializer2.peg');
     }).not.to.throw();
 
   });
@@ -46,7 +46,7 @@ describe('peg-import', function() {
   it('detects circular dependencies', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/circle/left.peg');
+      pegimport.generate('test/fixtures/circle/left.peg');
     }).to.throw(peg.GrammarError);
 
   });
@@ -54,7 +54,7 @@ describe('peg-import', function() {
   it('passes options straight through', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/initializer.peg', { optimize: 'size' });
+      pegimport.generate('test/fixtures/initializer.peg', { optimize: 'size' });
     }).not.to.throw();
 
   });
@@ -62,7 +62,7 @@ describe('peg-import', function() {
   it('treats internal rule name references correctly', function() {
 
     expect(function() {
-      pegimport.buildParser('test/fixtures/rulerefs.peg');
+      pegimport.generate('test/fixtures/rulerefs.peg');
     }).not.to.throw();
 
   });

--- a/test/spec/core.js
+++ b/test/spec/core.js
@@ -2,7 +2,8 @@
 'use strict';
 
 var pegimport = require('../../index'),
-  peg = require('pegjs');
+  peg = require('pegjs'),
+  expect = require('chai').expect;
 
 describe('peg-import', function() {
 


### PR DESCRIPTION
This updates both the testing libraries and the underlying PEG.js version (to the current latest, 0.10). Testing libraries were updated because the Mocha version used was not producing any output on my system, and so this was necessary to verify that the PEG.js upgrade worked correctly.

Because the underlying API and options of PEG.js itself (which are passed through) have changed, __this is a breaking change__ and therefore would require a bump of this library's version number to `0.3.0`. For that reason, I've also rolled in a `buildParser` -> `generate` API naming change to mirror that in PEG.js itself, since it will be a breaking release anyway.

All tests pass. I have not done any additional manual testing outside of the automated tests.